### PR TITLE
Use `姓名` for column name on committer/PMC pages in Chinese

### DIFF
--- a/src/zh/become_committer.md
+++ b/src/zh/become_committer.md
@@ -25,7 +25,7 @@ menu:
 <table border=0>
   <thead>
     <tr>
-      <th>Name</th>
+      <th>姓名</th>
     </tr>
   </thead>
   <tbody>

--- a/src/zh/become_pmc_member.md
+++ b/src/zh/become_pmc_member.md
@@ -25,7 +25,7 @@ menu:
 <table border=0>
   <thead>
     <tr>
-      <th>Name</th>
+      <th>姓名</th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
- Use `姓名` for column name on committer/PMC pages in Chinese

![image](https://user-images.githubusercontent.com/1935105/215402394-70640a7f-acf2-4779-b551-7946fc45e5c9.png)
