### PR TITLE
Improvements in committer lists

### DIFF
--- a/src/en/become_committer.md
+++ b/src/en/become_committer.md
@@ -22,76 +22,14 @@ menu:
 
 <img src="https://svn.apache.org/repos/asf/comdev/project-logos/originals/kyuubi-1.svg" alt="Kyuubi logo" width="30%" align="right" />
 
-## Become A Committer of Apache Kyuubi
-
-Anyone being supportive of the community and working in any of the
-CoPDoC areas can become an Apache Kyuubi committer. The CoPDoC is an
-acronym from ASF to describe how we recognize your contributions not
-only by code.
-
-- **Co**mmunity - You can join us via our mailing list, issue
-  trackers, discussions page to interact with community members, and
-  share vision and knowledge
-- **P**roject - a clear vision and consensus are needed
-- **Do**cumentation - without it, the stuff remains only in the minds
-  of the authors
-- **C**ode - discussion goes nowhere without code
-
-Apache Kyuubi community strives to be meritocratic. Thus, once someone
-has contributed sufficiently to any area of CoPDoC they can be a
-candidate for committer-ship and at last voted in as a Kyuubi
-committer. Being an Apache Kyuubi committer does not necessarily mean
-you must commit code with your commit privilege to the codebase; it
-means you are committed to the Kyuubi project and are productively
-contributing to our community's success.
-
-### Committer requirements:
-
-There are no strict rules for becoming a committer or PMC member.
-Candidates for new committers are typically people that are active
-contributors and community members. Anyway, if the rules can be
-clarified a little bit, it can somehow clear the doubts in the minds
-of contributors and make the community more transparent, reasonable,
-and fair.
-
-#### Continuous contributions
-
-Committer candidates should have a decent amount of continuous
-engagements and contributions (fixing bugs, adding new features,
-writing documentation, maintaining issues boards, code review, or answering
-community questions) to Kyuubi either by contributing to the codebase
-of the main website or Kyuubi's GitHub repositories.
-
-- +3 months with light activity and engagement.
-- +2 months of medium activity and engagement.
-- +1 month with solid activity and engagement.
-
-#### Quality of contributions
-- A solid general understanding of the project
-- Well tested, well-designed, following Apache Kyuubi coding
-  standards, and simple patches.
-- Well-organized and detailed user-oriented documentation.
-
-#### Community involvement
-
-- Be active, courteous, and respectful on the dev mailing list and
-  help mentor newer contributors
-  and users.
-- Be active, courteous, and respectful on the issue tracker for
-  project maintenance
-- Be active, courteous, and respectful for pull requests reviewing
-- Be involved in the design road map discussions with a professional
-  and diplomatic approach even if there is a disagreement
-- Promoting the project by writing articles or holding events
-
 ## Current committers
 
-<table class="ui selectable celled table">
+<table border=0>
   <thead>
     <tr>
       <th>Public Name</th>
-      <th>Apache Id</th>
-      <th>Github Id</th>
+      <th>Apache ID</th>
+      <th>Github ID</th>
     </tr>
   </thead>
   <tbody>
@@ -192,3 +130,66 @@ of the main website or Kyuubi's GitHub repositories.
     </tr>
   </tbody>
 </table>
+
+## Become A Committer of Apache Kyuubi
+
+Anyone being supportive of the community and working in any of the
+CoPDoC areas can become an Apache Kyuubi committer. The CoPDoC is an
+acronym from ASF to describe how we recognize your contributions not
+only by code.
+
+- **Co**mmunity - You can join us via our mailing list, issue
+  trackers, discussions page to interact with community members, and
+  share vision and knowledge
+- **P**roject - a clear vision and consensus are needed
+- **Do**cumentation - without it, the stuff remains only in the minds
+  of the authors
+- **C**ode - discussion goes nowhere without code
+
+Apache Kyuubi community strives to be meritocratic. Thus, once someone
+has contributed sufficiently to any area of CoPDoC they can be a
+candidate for committer-ship and at last voted in as a Kyuubi
+committer. Being an Apache Kyuubi committer does not necessarily mean
+you must commit code with your commit privilege to the codebase; it
+means you are committed to the Kyuubi project and are productively
+contributing to our community's success.
+
+### Committer requirements:
+
+There are no strict rules for becoming a committer or PMC member.
+Candidates for new committers are typically people that are active
+contributors and community members. Anyway, if the rules can be
+clarified a little bit, it can somehow clear the doubts in the minds
+of contributors and make the community more transparent, reasonable,
+and fair.
+
+#### Continuous contributions
+
+Committer candidates should have a decent amount of continuous
+engagements and contributions (fixing bugs, adding new features,
+writing documentation, maintaining issues boards, code review, or answering
+community questions) to Kyuubi either by contributing to the codebase
+of the main website or Kyuubi's GitHub repositories.
+
+- +3 months with light activity and engagement.
+- +2 months of medium activity and engagement.
+- +1 month with solid activity and engagement.
+
+#### Quality of contributions
+- A solid general understanding of the project
+- Well tested, well-designed, following Apache Kyuubi coding
+  standards, and simple patches.
+- Well-organized and detailed user-oriented documentation.
+
+#### Community involvement
+
+- Be active, courteous, and respectful on the dev mailing list and
+  help mentor newer contributors
+  and users.
+- Be active, courteous, and respectful on the issue tracker for
+  project maintenance
+- Be active, courteous, and respectful for pull requests reviewing
+- Be involved in the design road map discussions with a professional
+  and diplomatic approach even if there is a disagreement
+- Promoting the project by writing articles or holding events
+- 

--- a/src/en/become_committer.md
+++ b/src/en/become_committer.md
@@ -36,99 +36,99 @@ menu:
     <tr>
       <td>Akira Ajisaka</td>
       <td>aajisaka</td>
-      <td>aajisaka</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=aajisaka">aajisaka</a></td>
    </tr>
     <tr>
       <td>Bowen Liang</td>
       <td>bowenliang</td>
-      <td>bowenliang123</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=bowenliang123">bowenliang123</a></td>
     </tr>
     <tr>
       <td>Cheng Pan</td>
       <td>chengpan</td>
-      <td>pan3793</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=pan3793">pan3793</a></td>
     </tr>
     <tr>
       <td>Dongdong Hong</td>
       <td>hongdd</td>
-      <td>hddong</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=hddong">hddong</a></td>
     </tr>
     <tr>
       <td>Duo Zhang</td>
       <td>zhangduo</td>
-      <td>Apache9</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=Apache9">Apache9</a></td>
     </tr>
     <tr>
       <td>Fei Wang</td>
       <td>feiwang</td>
-      <td>turbofei</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=turbofei">turbofei</a></td>
     </tr>
     <tr>
       <td>Fu Chen</td>
       <td>fchen</td>
-      <td>cfmcgrady</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=cfmcgrady">cfmcgrady</a></td>
     </tr>
     <tr>
       <td>Hongxiang Jiang</td>
       <td>jhx1008</td>
-      <td>jhx1008</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=jhx1008">jhx1008</a></td>
     </tr>
     <tr>
       <td>Jeff Zhang</td>
       <td>zjffdu</td>
-      <td>zjffdu</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=zjffdu">zjffdu</a></td>
     </tr>
     <tr>
       <td>Kaifei Yi</td>
       <td>yikaifei</td>
-      <td>Yikf</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=Yikf">Yikf</a></td>
     </tr>
     <tr>
       <td>Kent Yao</td>
       <td>yao</td>
-      <td>yaooqinn</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=yaooqinn">yaooqinn</a></td>
     </tr>
     <tr>
       <td>Min Zhao</td>
       <td>zhaomin</td>
-      <td>zhaomin1423</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=zhaomin1423">zhaomin1423</a></td>
     </tr>
     <tr>
       <td>Nicholas Jiang</td>
       <td>nicholasjiang</td>
-      <td>SteNicholas</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=SteNicholas">SteNicholas</a></td>
     </tr>
     <tr>
       <td>Qingbo Jiao</td>
       <td>jiaoqingbo</td>
-      <td>jiaoqingbo</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=jiaoqingbo">jiaoqingbo</a></td>
     </tr>
     <tr>
       <td>Shaoyun Chen</td>
       <td>csy</td>
-      <td>cxzl25</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=cxzl25">cxzl25</a></td>
     </tr>
     <tr>
       <td>Vino Yang</td>
       <td>vinoyang</td>
-      <td>yanghua</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=yanghua">yanghua</a></td>
     </tr>
     <tr>
       <td>Willem Ning Jiang</td>
       <td>ningjiang</td>
-      <td>WillemJiang</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=WillemJiang">WillemJiang</a></td>
     </tr>
     <tr>
       <td>Xiduo You</td>
       <td>ulyssesyou</td>
-      <td>ulysses-you</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=ulysses-you">ulysses-you</a></td>
     </tr>
     <tr>
       <td>Zhen Wang</td>
       <td>wangzhen</td>
-      <td>wForget</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=wForget">wForget</a></td>
     </tr>
-  </tbody>
+</tbody>
 </table>
 
 ## Become A Committer of Apache Kyuubi

--- a/src/zh/become_committer.md
+++ b/src/zh/become_committer.md
@@ -26,65 +26,105 @@ menu:
   <thead>
     <tr>
       <th>姓名</th>
+      <th>Apache ID</th>
+      <th>Github ID</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Akira Ajisaka</td>
-    </tr>
+      <td>aajisaka</td>
+      <td>aajisaka</td>
+   </tr>
     <tr>
       <td>Bowen Liang</td>
+      <td>bowenliang</td>
+      <td>bowenliang123</td>
     </tr>
     <tr>
       <td>Cheng Pan</td>
+      <td>chengpan</td>
+      <td>pan3793</td>
     </tr>
     <tr>
       <td>Dongdong Hong</td>
+      <td>hongdd</td>
+      <td>hddong</td>
     </tr>
     <tr>
       <td>Duo Zhang</td>
+      <td>zhangduo</td>
+      <td>Apache9</td>
     </tr>
     <tr>
       <td>Fei Wang</td>
+      <td>feiwang</td>
+      <td>turbofei</td>
     </tr>
     <tr>
       <td>Fu Chen</td>
+      <td>fchen</td>
+      <td>cfmcgrady</td>
     </tr>
     <tr>
       <td>Hongxiang Jiang</td>
+      <td>jhx1008</td>
+      <td>jhx1008</td>
     </tr>
     <tr>
       <td>Jeff Zhang</td>
+      <td>zjffdu</td>
+      <td>zjffdu</td>
     </tr>
     <tr>
       <td>Kaifei Yi</td>
+      <td>yikaifei</td>
+      <td>Yikf</td>
     </tr>
     <tr>
       <td>Kent Yao</td>
+      <td>yao</td>
+      <td>yaooqinn</td>
     </tr>
     <tr>
       <td>Min Zhao</td>
+      <td>zhaomin</td>
+      <td>zhaomin1423</td>
     </tr>
     <tr>
       <td>Nicholas Jiang</td>
+      <td>nicholasjiang</td>
+      <td>SteNicholas</td>
     </tr>
     <tr>
       <td>Qingbo Jiao</td>
+      <td>jiaoqingbo</td>
+      <td>jiaoqingbo</td>
     </tr>
     <tr>
       <td>Shaoyun Chen</td>
+      <td>csy</td>
+      <td>cxzl25</td>
     </tr>
     <tr>
       <td>Vino Yang</td>
+      <td>vinoyang</td>
+      <td>yanghua</td>
     </tr>
     <tr>
       <td>Willem Ning Jiang</td>
+      <td>ningjiang</td>
+      <td>WillemJiang</td>
     </tr>
     <tr>
       <td>Xiduo You</td>
+      <td>ulyssesyou</td>
+      <td>ulysses-you</td>
     </tr>
     <tr>
       <td>Zhen Wang</td>
+      <td>wangzhen</td>
+      <td>wForget</td>
     </tr>
   </tbody>
 </table>

--- a/src/zh/become_committer.md
+++ b/src/zh/become_committer.md
@@ -34,99 +34,99 @@ menu:
     <tr>
       <td>Akira Ajisaka</td>
       <td>aajisaka</td>
-      <td>aajisaka</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=aajisaka">aajisaka</a></td>
    </tr>
     <tr>
       <td>Bowen Liang</td>
       <td>bowenliang</td>
-      <td>bowenliang123</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=bowenliang123">bowenliang123</a></td>
     </tr>
     <tr>
       <td>Cheng Pan</td>
       <td>chengpan</td>
-      <td>pan3793</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=pan3793">pan3793</a></td>
     </tr>
     <tr>
       <td>Dongdong Hong</td>
       <td>hongdd</td>
-      <td>hddong</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=hddong">hddong</a></td>
     </tr>
     <tr>
       <td>Duo Zhang</td>
       <td>zhangduo</td>
-      <td>Apache9</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=Apache9">Apache9</a></td>
     </tr>
     <tr>
       <td>Fei Wang</td>
       <td>feiwang</td>
-      <td>turbofei</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=turbofei">turbofei</a></td>
     </tr>
     <tr>
       <td>Fu Chen</td>
       <td>fchen</td>
-      <td>cfmcgrady</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=cfmcgrady">cfmcgrady</a></td>
     </tr>
     <tr>
       <td>Hongxiang Jiang</td>
       <td>jhx1008</td>
-      <td>jhx1008</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=jhx1008">jhx1008</a></td>
     </tr>
     <tr>
       <td>Jeff Zhang</td>
       <td>zjffdu</td>
-      <td>zjffdu</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=zjffdu">zjffdu</a></td>
     </tr>
     <tr>
       <td>Kaifei Yi</td>
       <td>yikaifei</td>
-      <td>Yikf</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=Yikf">Yikf</a></td>
     </tr>
     <tr>
       <td>Kent Yao</td>
       <td>yao</td>
-      <td>yaooqinn</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=yaooqinn">yaooqinn</a></td>
     </tr>
     <tr>
       <td>Min Zhao</td>
       <td>zhaomin</td>
-      <td>zhaomin1423</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=zhaomin1423">zhaomin1423</a></td>
     </tr>
     <tr>
       <td>Nicholas Jiang</td>
       <td>nicholasjiang</td>
-      <td>SteNicholas</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=SteNicholas">SteNicholas</a></td>
     </tr>
     <tr>
       <td>Qingbo Jiao</td>
       <td>jiaoqingbo</td>
-      <td>jiaoqingbo</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=jiaoqingbo">jiaoqingbo</a></td>
     </tr>
     <tr>
       <td>Shaoyun Chen</td>
       <td>csy</td>
-      <td>cxzl25</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=cxzl25">cxzl25</a></td>
     </tr>
     <tr>
       <td>Vino Yang</td>
       <td>vinoyang</td>
-      <td>yanghua</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=yanghua">yanghua</a></td>
     </tr>
     <tr>
       <td>Willem Ning Jiang</td>
       <td>ningjiang</td>
-      <td>WillemJiang</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=WillemJiang">WillemJiang</a></td>
     </tr>
     <tr>
       <td>Xiduo You</td>
       <td>ulyssesyou</td>
-      <td>ulysses-you</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=ulysses-you">ulysses-you</a></td>
     </tr>
     <tr>
       <td>Zhen Wang</td>
       <td>wangzhen</td>
-      <td>wForget</td>
+      <td><a href="https://github.com/apache/kyuubi/commits?author=wForget">wForget</a></td>
     </tr>
-  </tbody>
+</tbody>
 </table>
 
 任何支持社区并在任何 CoPDoC 领域工作的人都可以成为 Apache Kyuubi Committer。


### PR DESCRIPTION
- move the current committer list to the top in en/become_committer.md , to make in same order as in `zh/become_committer.md`, and the `become_pmc_member.md` of `zh` or `en` languages
- add Apache id and Github id in `zh/become_committer.md`, as in `en/become_committer.md`
- add links of authored commits for committers

Before:
`en/become_committer.md`:
<img width="703" alt="image" src="https://user-images.githubusercontent.com/1935105/218317032-1084a2ab-4d6f-43a3-8cd3-b99c503fd82f.png">

`zh/become_committer.md`:
<img width="706" alt="image" src="https://user-images.githubusercontent.com/1935105/218317003-c181ff5e-75e7-427c-8370-6ec8f9e879ff.png">




After:
`en/become_committer.md`:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/1935105/218317059-82616dcc-43cd-42fe-9119-6b3a75a5ad97.png">


`zh/become_committer.md`:
<img width="708" alt="image" src="https://user-images.githubusercontent.com/1935105/218316984-3199ff28-8b03-4675-a486-dffcee6189ee.png">
