### PR TITLE
Add links for commits in 1.7.0 release note and fix a typo.

### DIFF
--- a/src/en/release/1.7.0.md
+++ b/src/en/release/1.7.0.md
@@ -36,119 +36,119 @@ _wpas_done_all: '1'
 
 ### Server
 
-- [KYUUBI #2887] Add a POLLING balance policy for engine pool
-- [KYUUBI #3089] Support custom event handler
-- [KYUUBI #3449] Change default server info provider to ENGINE
-- [KYUUBI #3545] [KYUUBI #3563] Support restrict spark configurations
-- [KYUUBI #3554] REST API functions/command-line tool enhancements
-- [KYUUBI #3577] Transfer connection url when opening session
-- [KYUUBI #3615] Retry opening the engine when encountering a special error
-- [KYUUBI #3658] Support SSL for Kyuubi thrift binary connection
-- [KYUUBI #3659] Support alternative keys in ConfigBuilder
-- [KYUUBI #3663] Support auto build Kubernetes client from env when Kyuubi running in Pod
-- [KYUUBI #3742] Add FileSessionConfAdvisor to manage session level configuration
-- [KYUUBI #3766] Support real user for KyuubiSession
-- [KYUUBI #3835] Allow to use spark-internal as resource for batch job
-- [KYUUBI #3839] Introduce signature mechanism to protect session variable on engine side
-- [KYUUBI #3844] Forward the server ip in openSession
-- [KYUUBI #3847] Add jdbc-shaded profile to support IDE debug
-- [KYUUBI #3863] Arrow-based results serialization
-- [KYUUBI #3867] Init SQL scripts should create table iff table does not exist
-- [KYUUBI #3887] Provide kyuubiServerPrincipal as alias for principal in JDBC parameter
-- [KYUUBI #3897] Supplying pluggable GroupProvider
-- [KYUUBI #3901] Introduce Trino frontend (experimental)
-- [KYUUBI #3922] Only the ApplicationInfo with non-empty id is valid for BatchJobSubmission
-- [KYUUBI #3923] Add dedicated batch session idle timeout
-- [KYUUBI #3926] Introduce antlr4 to parse query statement
-- [KYUUBI #3928] Application state mapping considers FinalApplicationStatus
-- [KYUUBI #3950] Fix the batch metadata in-consistent issue on open batch session failure
-- [KYUUBI #3975] Support to post batch session/operation event
-- [KYUUBI #3983] [KYUUBI #3982] Introduce refreshing user defaults configs
-- [KYUUBI #4021] Fix async start engine failure resulting in inaccurate operation metrics
-- [KYUUBI #4106] Introduce resource file uploading in batch creation via REST API
-- [KYUUBI #4119] Return app submission time for batch
-- [KYUUBI #4145] Change lock and polling seq_num path on service discovery
-- [KYUUBI #4151] Support to ignore subdomain when engine pool conditions are met
-- [KYUUBI #4152] Enhance LDAP authentication
-- [KYUUBI #4241] Only force close engine ref when open session failed
-- [KYUUBI #4322] MySQL URL configuration joiner should use `&` instead of `;`
-- [KYUUBI #4352] Support System.gc() with periodic GC interval
-- [KYUUBI #4360] Support to refresh the unlimited users for session limiter
-- [KYUUBI #4372] Support to return null value for OperationsResource RowSet
-- [KYUUBI #4390] Allow user to provide batch id on submitting batch job
-- [KYUUBI #4418] Allow disable async retry and fail fast on unrecoverable DB error
-- [KYUUBI #4419] Implement simple EngineSecuritySecretProvider
+- [[KYUUBI #2887] Add a POLLING balance policy for engine pool](https://github.com/apache/kyuubi/commit/c25961ea0271ea38e67e046fc3696605df2958b8)
+- [[KYUUBI #3089] Support custom event handler](https://github.com/apache/kyuubi/commit/fae9883ca3acdada0a28621828a7d7e9a17da9a3)
+- [[KYUUBI #3449] Change default server info provider to ENGINE](https://github.com/apache/kyuubi/commit/4de12cdb6f6cddc86bdfbe55053dd0dd2ddd6df0)
+- [[KYUUBI #3545] [KYUUBI #3563] Support restrict spark configurations](https://github.com/apache/kyuubi/commit/bb50c52c2f6f2068dbd9897cc04280b63b299f2f)
+- [[KYUUBI #3554] REST API functions/command-line tool enhancements](https://github.com/apache/kyuubi/issues/3554)
+- [[KYUUBI #3577] Transfer connection url when opening session](https://github.com/apache/kyuubi/commit/35f3917e5d506cdd8a7063003522590520a9ce64)
+- [[KYUUBI #3615] Retry opening the engine when encountering a special error](https://github.com/apache/kyuubi/commit/d87a6c7567721aa277f137449afbabcd2d3b3b53)
+- [[KYUUBI #3658] Support SSL for Kyuubi thrift binary connection](https://github.com/apache/kyuubi/commit/7bcb522d6e26bf1fb8403620da02d79e6af05d91)
+- [[KYUUBI #3659] Support alternative keys in ConfigBuilder](https://github.com/apache/kyuubi/commit/a6832b7ab6e979e9680cad554130234871142f63)
+- [[KYUUBI #3663] Support auto build Kubernetes client from env when Kyuubi running in Pod](https://github.com/apache/kyuubi/commit/9827c60aa424b61a6fd32e4c55c7651e56e0002c)
+- [[KYUUBI #3742] Add FileSessionConfAdvisor to manage session level configuration](https://github.com/apache/kyuubi/commit/8788c3b2f348d880c35bdc7c36d84f5ad9d05cfe)
+- [[KYUUBI #3766] Support real user for KyuubiSession](https://github.com/apache/kyuubi/commit/20fca4cfa48a8d8b8c84d9181c490dc37de460bf)
+- [[KYUUBI #3835] Allow to use spark-internal as resource for batch job](https://github.com/apache/kyuubi/commit/b225a4293608c128c8d3b3bb0f0961944ade7bd1)
+- [[KYUUBI #3839] Introduce signature mechanism to protect session variable on engine side](https://github.com/apache/kyuubi/commit/4b74129372448925fd5de38cc901edaea164166a)
+- [[KYUUBI #3844] Forward the server ip in openSession](https://github.com/apache/kyuubi/commit/ce11e35822b73c688cec1337161dbf5ebf77d0d3)
+- [[KYUUBI #3847] Add jdbc-shaded profile to support IDE debug](https://github.com/apache/kyuubi/commit/e49f7754316263df6b4927aa3826ba2a781dab87)
+- [[KYUUBI #3863] Arrow-based results serialization](https://github.com/apache/kyuubi/issues/3863)
+- [[KYUUBI #3867] Init SQL scripts should create table iff table does not exist](https://github.com/apache/kyuubi/commit/325668325b30c5e711dc207cc7e4f5aba35a90d7)
+- [[KYUUBI #3887] Provide kyuubiServerPrincipal as alias for principal in JDBC parameter](https://github.com/apache/kyuubi/commit/70c0451f4f670d50a72f093adca0b91fa49f8d1c)
+- [[KYUUBI #3897] Supplying pluggable GroupProvider](https://github.com/apache/kyuubi/commit/4730d11ad7ac210e47e6f5293b28e260279bafa3)
+- [[KYUUBI #3901] Introduce Trino frontend (experimental)](https://github.com/apache/kyuubi/issues/3901)
+- [[KYUUBI #3922] Only the ApplicationInfo with non-empty id is valid for BatchJobSubmission](https://github.com/apache/kyuubi/commit/1288c2d047268a115d6851f570e257b2013e5a93)
+- [[KYUUBI #3923] Add dedicated batch session idle timeout](https://github.com/apache/kyuubi/commit/93db224eb0a90efab47d55ed7c2a56df41b53de1)
+- [[KYUUBI #3926] Introduce antlr4 to parse query statement](https://github.com/apache/kyuubi/commit/7b5af4ae09d265953d0f26561c668e6c7e77090d)
+- [[KYUUBI #3928] Application state mapping considers FinalApplicationStatus](https://github.com/apache/kyuubi/commit/27b525b5d6f69ccc70b72f388315583587ca6697)
+- [[KYUUBI #3950] Fix the batch metadata in-consistent issue on open batch session failure](https://github.com/apache/kyuubi/commit/eb98f1e2339aba6b02af1af89195f89b52034ebc)
+- [[KYUUBI #3975] Support to post batch session/operation event](https://github.com/apache/kyuubi/commit/40009722cbeb54d1cc1c6e2ac1948bfd6667fb98)
+- [[KYUUBI #3983] [KYUUBI #3982] Introduce refreshing user defaults configs](https://github.com/apache/kyuubi/commit/75d0b7f6b7889b48761c499a697814b4b0bf9613)
+- [[KYUUBI #4021] Fix async start engine failure resulting in inaccurate operation metrics](https://github.com/apache/kyuubi/commit/9fd3b80785e949d32bd11e6047cba30d0afd8d5a)
+- [[KYUUBI #4106] Introduce resource file uploading in batch creation via REST API](https://github.com/apache/kyuubi/commit/501c97f3a362679ea964c2ced7b59ca48ee4f855)
+- [[KYUUBI #4119] Return app submission time for batch](https://github.com/apache/kyuubi/commit/35824f5f2c0f617c51cc9ebfa60799fefffee237)
+- [[KYUUBI #4145] Change lock and polling seq_num path on service discovery](https://github.com/apache/kyuubi/commit/547e5ca6176d386f5d8a8b9aadb9c285450f0e37)
+- [[KYUUBI #4151] Support to ignore subdomain when engine pool conditions are met](https://github.com/apache/kyuubi/commit/03fe8a8b96c43a9a9dcb5f0d80cf1b2d97404d8c)
+- [[KYUUBI #4152] Enhance LDAP authentication](https://github.com/apache/kyuubi/commit/eb1b11cd171fd4475cd2168e1d2d573232e16bd9)
+- [[KYUUBI #4241] Only force close engine ref when open session failed](https://github.com/apache/kyuubi/commit/eb1b11cd171fd4475cd2168e1d2d573232e16bd9)
+- [[KYUUBI #4322] MySQL URL configuration joiner should use `&` instead of `;`](https://github.com/apache/kyuubi/commit/fcd3e6f7457fdc5c9ee2f671da4c4940456be79b)
+- [[KYUUBI #4352] Support System.gc() with periodic GC interval](https://github.com/apache/kyuubi/commit/2db326ced9c55bcee41026dc6afd29b40786f0d7)
+- [[KYUUBI #4360] Support to refresh the unlimited users for session limiter](https://github.com/apache/kyuubi/commit/709c66454dfe966a57e39469b4ae862f037c6912)
+- [[KYUUBI #4372] Support to return null value for OperationsResource RowSet](https://github.com/apache/kyuubi/commit/c4955e601a561ce6b483f90d3022fe6d36cb4e03)
+- [[KYUUBI #4390] Allow user to provide batch id on submitting batch job](https://github.com/apache/kyuubi/commit/ac49c77e02c8a3a60df8f5998f4549b6480f91a7)
+- [[KYUUBI #4418] Allow disable async retry and fail fast on unrecoverable DB error](https://github.com/apache/kyuubi/commit/869a008e29d130e22709628243028e3c9d6e3bc3)
+- [[KYUUBI #4419] Implement simple EngineSecuritySecretProvider](https://github.com/apache/kyuubi/commit/4ffe8922d5d95eba6ea6e722876500c8c84b0c94)
 
 ### Client
 
-- [KYUUBI #3973] Fix conf fallback for `kyuubi-ctl list server`
-- [KYUUBI #4006] Fix the incorrect execution of the source command
-- [KYUUBI #4067] Reset the operation log before fetching new one
-- [KYUUBI #4216] Support to transfer client version for JDBC and REST client
-- [KYUUBI #4221] REST client for creating batch with uploading resource file
-- [KYUUBI #4311] Fix the wrong parsing of JVM parameters in JDBC url
-- [KYUUBI #4334] REST client should catch `NoHttpResponse Exception` and retry
+- [[KYUUBI #3973] Fix conf fallback for `kyuubi-ctl list server`](https://github.com/apache/kyuubi/commit/4d6942cb2b5ef68c3026b4e6f875f8ab1b174d0e)
+- [[KYUUBI #4006] Fix the incorrect execution of the source command](https://github.com/apache/kyuubi/commit/a494aa9b8765f3183c960825a5b1a1b47bc2b8a7)
+- [[KYUUBI #4067] Reset the operation log before fetching new one](https://github.com/apache/kyuubi/commit/2c6f17daf13c94d8b0644e59cd48b9c0a93478c7)
+- [[KYUUBI #4216] Support to transfer client version for JDBC and REST client](https://github.com/apache/kyuubi/commit/c14e914f0cb9b72d74842bd7c77a320c83e9b5cb)
+- [[KYUUBI #4221] REST client for creating batch with uploading resource file](https://github.com/apache/kyuubi/commit/37cf4cb29ec61c82ed022b81fc11c6908ea785e5)
+- [[KYUUBI #4311] Fix the wrong parsing of JVM parameters in JDBC url](https://github.com/apache/kyuubi/commit/89d4a4b8446a7054e18efd817cb787aa8aa700ae)
+- [[KYUUBI #4334] REST client should catch `NoHttpResponse Exception` and retry](https://github.com/apache/kyuubi/commit/f03678d0f39927391a24897ac6bd86a3b43f1b44)
 
 ### Spark Engine
 
-- [KYUUBI #3128] Support CostMode for PlanOnlyStatement
-- [KYUUBI #3385] Set executor Pod name prefix if missing in Spark on K8s case
-- [KYUUBI #3441] Change default Spark version to 3.3.1
-- [KYUUBI #3487] Support Kyuubi as Spark dialect
-- [KYUUBI #3776] Revise Kyuubi Spark engine shaded
-- [KYUUBI #3780] Add support for executing Python/PySpark scripts (experimental)
-- [KYUUBI #3792] Engine UI support grace stop
-- [KYUUBI #3801] Correctly calculate active stages in SQLOperationListener
-- [KYUUBI #3851] Support auto set up spark.master when Kyuubi running inside K8s Pod
-- [KYUUBI #3885] Fix memory leak when using incremental collect mode
-- [KYUUBI #3892] Remove sensitive kyuubi.engine.credentials from spark conf
-- [KYUUBI #4035] Post SparkOperationEvent and show sessionId for statements
-- [KYUUBI #4150] Support to execute Scala statement synchronized to prevent conflicts
-- [KYUUBI #4316] Fix returned Timestamp values may lose precision
-- [KYUUBI #4336] Avoid listing all schemas for Spark session catalog on schema pruning
-- [KYUUBI #4407] Adapt SLF4J 2.x
-- [KYUUBI #4412] Align the session handle between server and engine for Spark engine
+- [[KYUUBI #3128] Support CostMode for PlanOnlyStatement](https://github.com/apache/kyuubi/commit/8870183ed70f531f73abfd80f15640486a4fabef)
+- [[KYUUBI #3385] Set executor Pod name prefix if missing in Spark on K8s case](https://github.com/apache/kyuubi/commit/c454bfdcbeb336d47d670ccf5ff84e45bf79a20b)
+- [[KYUUBI #3441] Change default Spark version to 3.3.1](https://github.com/apache/kyuubi/commit/f7c08dcafac40e5b4f377602abbb676744e671e0)
+- [[KYUUBI #3487] Support Kyuubi as Spark dialect](https://github.com/apache/kyuubi/commit/1a9bf9305119ca43d3aa0dfb7fe55661679463e0)
+- [[KYUUBI #3776] Revise Kyuubi Spark engine shaded](https://github.com/apache/kyuubi/commit/72c1f53dd0c4a8eafb9ee2b13c77240b711cb58d)
+- [[KYUUBI #3780] Add support for executing Python/PySpark scripts (experimental)](https://github.com/apache/kyuubi/issues/3780)
+- [[KYUUBI #3792] Engine UI support grace stop](https://github.com/apache/kyuubi/commit/7ee25b2220d683fc1361511412c06f2d3b49cc31)
+- [[KYUUBI #3801] Correctly calculate active stages in SQLOperationListener](https://github.com/apache/kyuubi/commit/979881d6877bef42faee3410f5796966258e235e)
+- [[KYUUBI #3851] Support auto set up spark.master when Kyuubi running inside K8s Pod](https://github.com/apache/kyuubi/commit/5fdd44fe6b20ab1a4a85b80156bbb8d0bb14d214)
+- [[KYUUBI #3885] Fix memory leak when using incremental collect mode](https://github.com/apache/kyuubi/commit/172f42735509222373c8012bb9f821600f6d722d)
+- [[KYUUBI #3892] Remove sensitive kyuubi.engine.credentials from spark conf](https://github.com/apache/kyuubi/commit/87d01b577cfd006f3f66b689f05da32ce3d1b947)
+- [[KYUUBI #4035] Post SparkOperationEvent and show sessionId for statements](https://github.com/apache/kyuubi/commit/a96df17bcdba2b9de3d4c6e520f8baf1f03c45ce)
+- [[KYUUBI #4150] Support to execute Scala statement synchronized to prevent conflicts](https://github.com/apache/kyuubi/commit/4669163176c71f9ecce5b8bd238ff61d73e59e23)
+- [[KYUUBI #4316] Fix returned Timestamp values may lose precision](https://github.com/apache/kyuubi/commit/8fe794709bb2a3e28baa6dccf89f62b1dac5c285)
+- [[KYUUBI #4336] Avoid listing all schemas for Spark session catalog on schema pruning](https://github.com/apache/kyuubi/commit/89fe835b93ea26d1c2ce5d9991a284449d16caa2)
+- [[KYUUBI #4407] Adapt SLF4J 2.x](https://github.com/apache/kyuubi/commit/0175e4649a66c7e0e7cda5914e730382c5c763b0)
+- [[KYUUBI #4412] Align the session handle between server and engine for Spark engine](https://github.com/apache/kyuubi/commit/c0241052ae156971a07ee30d89bc4a02d6115d3e)
 
 ### Spark Authz Plugin 
 
-- [KYUUBI #3424] Access privilege checks for namespaces and tables of DatasourceV2
-- [KYUUBI #3515] Support Iceberg commands and skip apply row-filter to output tables
-- [KYUUBI #3325] Privilege checks for permanent views and skipping shadowed tables
-- [KYUUBI #3300] Support user group based policies from Ranger
-- [KYUUBI #3371] Ranger client support sending requests in batch
-- [KYUUBI #3581] Support row filter and data masking on permanent views
-- [KYUUBI #3607] Support {OWNER} variable defined in Ranger policy
-- [KYUUBI #3904] New Authz Plan Serde Layer
-- [KYUUBI #4076] Modified query plan should correctly report stats
-- [KYUUBI #4270] Register shutdown hook for plugin cleanup
-- [KYUUBI #4255] Handle describe relation for V2 relations
-- [KYUUBI #4262] Rename table requires ALTER privilege of the source table 
-- [KYUUBI #4202] Fix reference resolution when data masking enabled for V2 relations
-- [KYUUBI #4437] Fix dependencies conflict by replacing `jersey-bundle` with `jersey-client`
+- [[KYUUBI #3424] Access privilege checks for namespaces and tables of DatasourceV2](https://github.com/apache/kyuubi/commit/6aacbb754448ac32d05288ab1d1bb1e6b78bd438)
+- [[KYUUBI #3515] Support Iceberg commands and skip apply row-filter to output tables](https://github.com/apache/kyuubi/commit/0c2091cd03c92f4b3e402a2dc84ef35cdc5d5bea)
+- [[KYUUBI #3325] Privilege checks for permanent views and skipping shadowed tables](https://github.com/apache/kyuubi/commit/1989e4c7934d7f4d80f488fd0bf9e5adbda5ed9c)
+- [[KYUUBI #3300] Support user group based policies from Ranger](https://github.com/apache/kyuubi/commit/c5e57e946b3d271b4bc0b760d143533c03f1a333)
+- [[KYUUBI #3371] Ranger client support sending requests in batch](https://github.com/apache/kyuubi/commit/23a8ccd538c72ba38770941928f5a7e161dd2af7)
+- [[KYUUBI #3581] Support row filter and data masking on permanent views](https://github.com/apache/kyuubi/commit/8207b106207cb119c859cc81c59decac9b09b799)
+- [[KYUUBI #3607] Support {OWNER} variable defined in Ranger policy](https://github.com/apache/kyuubi/issues/3607)
+- [[KYUUBI #3904] New Authz Plan Serde Layer](https://github.com/apache/kyuubi/commit/2540f44a8769a538a34a3256fb66f4346d6de79e)
+- [[KYUUBI #4076] Modified query plan should correctly report stats](https://github.com/apache/kyuubi/commit/71e46bd3168c4ce530d96d38ebc7e9209f03c498)
+- [[KYUUBI #4270] Register shutdown hook for plugin cleanup](https://github.com/apache/kyuubi/commit/0eff3cec535464f08cf6162971b4a80a48536132)
+- [[KYUUBI #4255] Handle describe relation for V2 relations](https://github.com/apache/kyuubi/commit/e5743c8309978cfc2bf430721d0c9d2d46909883)
+- [[KYUUBI #4262] Rename table requires ALTER privilege of the source table](https://github.com/apache/kyuubi/commit/68cc0e40970453e59351d199396a2c546afb8c08) 
+- [[KYUUBI #4202] Fix reference resolution when data masking enabled for V2 relations](https://github.com/apache/kyuubi/commit/5aed270c453516fd3559aa668e56b2e1badf1c93)
+- [[KYUUBI #4437] Fix dependencies conflict by replacing `jersey-bundle` with `jersey-client`](https://github.com/apache/kyuubi/commit/355ed803b6d8b55c7b076640d48fcf01b951782f)
 
 ### Other Spark Extensions
 
-- [KYUUBI #2282] Introduce Spark Lineage plugin (experimental)
-- [KYUUBI #3365] Introduce Spark Hive connector (experimental)
-- [KYUUBI #3601] Support infer columns for rebalance and sort
-- [KYUUBI #3962] Add two conditions to decide if add shuffle before writing
-- [KYUUBI #3988] Final stage config isolation support write only
-- [KYUUBI #3893] UnspecifiedDistribution does not have default partitioning
+- [[KYUUBI #2282] Introduce Spark Lineage plugin (experimental)](https://github.com/apache/kyuubi/commit/9716548380a21f2608ec1f413f1f6986366b4f18)
+- [[KYUUBI #3365] Introduce Spark Hive connector (experimental)](https://github.com/apache/kyuubi/issues/3365)
+- [[KYUUBI #3601] Support infer columns for rebalance and sort](https://github.com/apache/kyuubi/commit/2acee9ea977f7b5ae3d270be93ec0b2537eac4dd)
+- [[KYUUBI #3962] Add two conditions to decide if add shuffle before writing](https://github.com/apache/kyuubi/commit/fa9e6be663f4eb4f611963583a4fa6a7340a8cef)
+- [[KYUUBI #3988] Final stage config isolation support write only](https://github.com/apache/kyuubi/commit/04953500821840e5e99fda0245400d5fea1e6182)
+- [[KYUUBI #3893] UnspecifiedDistribution does not have default partitioning](https://github.com/apache/kyuubi/commit/8ef6494e4a887145b9cbb451ce7b63b435557fc1)
 
 ### Flink Engine
 
-- [KYUUBI #3514] Support Flink 1.16
-- [KYUUBI #3604] Propagate HADOOP_PROXY_USER on launching Flink engine
-- [KYUUBI #3717] Support Flink engine see primary keys
+- [[KYUUBI #3514] Support Flink 1.16](https://github.com/apache/kyuubi/commit/214d238902712e3f2b6e49507c2fcf762f80ef9b)
+- [[KYUUBI #3604] Propagate HADOOP_PROXY_USER on launching Flink engine](https://github.com/apache/kyuubi/commit/26b78f5c1fb02b9e6bdce96b633bacddb43c229f)
+- [[KYUUBI #3717] Support Flink engine see primary keys](https://github.com/apache/kyuubi/commit/a2604b1a89a115c339e87f7679188e205abb9707)
 
 ### Other Notable Changes
 
-- [KYUUBI #3473] Add Docker Compose based Kyuubi playground
-- [KYUUBI #3903] Support generate `kyuubi-version-info.properties` on Windows
-- [KYUUBI #4000] JDBC engine supports Apache Phoenix
-- [KYUUBI #4288] Use eclipse-temurin:8-jdk-focal as default base image
-- [KYUUBI #4320] Trino engine supports GetPrimaryKeys
-- [KYUUBI #4473] Helm Chart improvements
+- [[KYUUBI #3473] Add Docker Compose based Kyuubi playground](https://github.com/apache/kyuubi/commit/5dd245dfa1e7302fbdcc743eba0d4fd5f2ab1655)
+- [[KYUUBI #3903] Support generate `kyuubi-version-info.properties` on Windows](https://github.com/apache/kyuubi/commit/730fd57ccf6accf5636ad7bef13b16e8727de8ee)
+- [[KYUUBI #4000] JDBC engine supports Apache Phoenix](https://github.com/apache/kyuubi/commit/32b06c648ac34be7a3478026a40cff353f5d7b8f)
+- [[KYUUBI #4288] Use eclipse-temurin:8-jdk-focal as default base image](https://github.com/apache/kyuubi/commit/5318585550bd1e0921e95fea10637d3fe4b04ea3)
+- [[KYUUBI #4320] Trino engine supports GetPrimaryKeys](https://github.com/apache/kyuubi/commit/02deaf4756fef953d706f171d87c5d0dd760f264)
+- [[KYUUBI #4473] Helm Chart improvements](https://github.com/apache/kyuubi/issues/4473)
 
 ### Credits
 

--- a/src/en/release/1.7.0.md
+++ b/src/en/release/1.7.0.md
@@ -53,7 +53,7 @@ _wpas_done_all: '1'
 - [[KYUUBI #3844] Forward the server ip in openSession](https://github.com/apache/kyuubi/commit/ce11e35822b73c688cec1337161dbf5ebf77d0d3)
 - [[KYUUBI #3847] Add jdbc-shaded profile to support IDE debug](https://github.com/apache/kyuubi/commit/e49f7754316263df6b4927aa3826ba2a781dab87)
 - [[KYUUBI #3863] Arrow-based results serialization](https://github.com/apache/kyuubi/issues/3863)
-- [[KYUUBI #3867] Init SQL scripts should create table iff table does not exist](https://github.com/apache/kyuubi/commit/325668325b30c5e711dc207cc7e4f5aba35a90d7)
+- [[KYUUBI #3867] Init SQL scripts should create table if table does not exist](https://github.com/apache/kyuubi/commit/325668325b30c5e711dc207cc7e4f5aba35a90d7)
 - [[KYUUBI #3887] Provide kyuubiServerPrincipal as alias for principal in JDBC parameter](https://github.com/apache/kyuubi/commit/70c0451f4f670d50a72f093adca0b91fa49f8d1c)
 - [[KYUUBI #3897] Supplying pluggable GroupProvider](https://github.com/apache/kyuubi/commit/4730d11ad7ac210e47e6f5293b28e260279bafa3)
 - [[KYUUBI #3901] Introduce Trino frontend (experimental)](https://github.com/apache/kyuubi/issues/3901)

--- a/src/zh/release/1.7.0.md
+++ b/src/zh/release/1.7.0.md
@@ -53,7 +53,7 @@ _wpas_done_all: '1'
 - [[KYUUBI #3844] Forward the server ip in openSession](https://github.com/apache/kyuubi/commit/ce11e35822b73c688cec1337161dbf5ebf77d0d3)
 - [[KYUUBI #3847] Add jdbc-shaded profile to support IDE debug](https://github.com/apache/kyuubi/commit/e49f7754316263df6b4927aa3826ba2a781dab87)
 - [[KYUUBI #3863] Arrow-based results serialization](https://github.com/apache/kyuubi/issues/3863)
-- [[KYUUBI #3867] Init SQL scripts should create table iff table does not exist](https://github.com/apache/kyuubi/commit/325668325b30c5e711dc207cc7e4f5aba35a90d7)
+- [[KYUUBI #3867] Init SQL scripts should create table if table does not exist](https://github.com/apache/kyuubi/commit/325668325b30c5e711dc207cc7e4f5aba35a90d7)
 - [[KYUUBI #3887] Provide kyuubiServerPrincipal as alias for principal in JDBC parameter](https://github.com/apache/kyuubi/commit/70c0451f4f670d50a72f093adca0b91fa49f8d1c)
 - [[KYUUBI #3897] Supplying pluggable GroupProvider](https://github.com/apache/kyuubi/commit/4730d11ad7ac210e47e6f5293b28e260279bafa3)
 - [[KYUUBI #3901] Introduce Trino frontend (experimental)](https://github.com/apache/kyuubi/issues/3901)

--- a/src/zh/release/1.7.0.md
+++ b/src/zh/release/1.7.0.md
@@ -36,119 +36,119 @@ _wpas_done_all: '1'
 
 ### Server
 
-- [KYUUBI #2887] Add a POLLING balance policy for engine pool
-- [KYUUBI #3089] Support custom event handler
-- [KYUUBI #3449] Change default server info provider to ENGINE
-- [KYUUBI #3545] [KYUUBI #3563] Support restrict spark configurations
-- [KYUUBI #3554] REST API functions/command-line tool enhancements
-- [KYUUBI #3577] Transfer connection url when opening session
-- [KYUUBI #3615] Retry opening the engine when encountering a special error
-- [KYUUBI #3658] Support SSL for Kyuubi thrift binary connection
-- [KYUUBI #3659] Support alternative keys in ConfigBuilder
-- [KYUUBI #3663] Support auto build Kubernetes client from env when Kyuubi running in Pod
-- [KYUUBI #3742] Add FileSessionConfAdvisor to manage session level configuration
-- [KYUUBI #3766] Support real user for KyuubiSession
-- [KYUUBI #3835] Allow to use spark-internal as resource for batch job
-- [KYUUBI #3839] Introduce signature mechanism to protect session variable on engine side
-- [KYUUBI #3844] Forward the server ip in openSession
-- [KYUUBI #3847] Add jdbc-shaded profile to support IDE debug
-- [KYUUBI #3863] Arrow-based results serialization
-- [KYUUBI #3867] Init SQL scripts should create table iff table does not exist
-- [KYUUBI #3887] Provide kyuubiServerPrincipal as alias for principal in JDBC parameter
-- [KYUUBI #3897] Supplying pluggable GroupProvider
-- [KYUUBI #3901] Introduce Trino frontend (experimental)
-- [KYUUBI #3922] Only the ApplicationInfo with non-empty id is valid for BatchJobSubmission
-- [KYUUBI #3923] Add dedicated batch session idle timeout
-- [KYUUBI #3926] Introduce antlr4 to parse query statement
-- [KYUUBI #3928] Application state mapping considers FinalApplicationStatus
-- [KYUUBI #3950] Fix the batch metadata in-consistent issue on open batch session failure
-- [KYUUBI #3975] Support to post batch session/operation event
-- [KYUUBI #3983] [KYUUBI #3982] Introduce refreshing user defaults configs
-- [KYUUBI #4021] Fix async start engine failure resulting in inaccurate operation metrics
-- [KYUUBI #4106] Introduce resource file uploading in batch creation via REST API
-- [KYUUBI #4119] Return app submission time for batch
-- [KYUUBI #4145] Change lock and polling seq_num path on service discovery
-- [KYUUBI #4151] Support to ignore subdomain when engine pool conditions are met
-- [KYUUBI #4152] Enhance LDAP authentication
-- [KYUUBI #4241] Only force close engine ref when open session failed
-- [KYUUBI #4322] MySQL URL configuration joiner should use `&` instead of `;`
-- [KYUUBI #4352] Support System.gc() with periodic GC interval
-- [KYUUBI #4360] Support to refresh the unlimited users for session limiter
-- [KYUUBI #4372] Support to return null value for OperationsResource RowSet
-- [KYUUBI #4390] Allow user to provide batch id on submitting batch job
-- [KYUUBI #4418] Allow disable async retry and fail fast on unrecoverable DB error
-- [KYUUBI #4419] Implement simple EngineSecuritySecretProvider
+- [[KYUUBI #2887] Add a POLLING balance policy for engine pool](https://github.com/apache/kyuubi/commit/c25961ea0271ea38e67e046fc3696605df2958b8)
+- [[KYUUBI #3089] Support custom event handler](https://github.com/apache/kyuubi/commit/fae9883ca3acdada0a28621828a7d7e9a17da9a3)
+- [[KYUUBI #3449] Change default server info provider to ENGINE](https://github.com/apache/kyuubi/commit/4de12cdb6f6cddc86bdfbe55053dd0dd2ddd6df0)
+- [[KYUUBI #3545] [KYUUBI #3563] Support restrict spark configurations](https://github.com/apache/kyuubi/commit/bb50c52c2f6f2068dbd9897cc04280b63b299f2f)
+- [[KYUUBI #3554] REST API functions/command-line tool enhancements](https://github.com/apache/kyuubi/issues/3554)
+- [[KYUUBI #3577] Transfer connection url when opening session](https://github.com/apache/kyuubi/commit/35f3917e5d506cdd8a7063003522590520a9ce64)
+- [[KYUUBI #3615] Retry opening the engine when encountering a special error](https://github.com/apache/kyuubi/commit/d87a6c7567721aa277f137449afbabcd2d3b3b53)
+- [[KYUUBI #3658] Support SSL for Kyuubi thrift binary connection](https://github.com/apache/kyuubi/commit/7bcb522d6e26bf1fb8403620da02d79e6af05d91)
+- [[KYUUBI #3659] Support alternative keys in ConfigBuilder](https://github.com/apache/kyuubi/commit/a6832b7ab6e979e9680cad554130234871142f63)
+- [[KYUUBI #3663] Support auto build Kubernetes client from env when Kyuubi running in Pod](https://github.com/apache/kyuubi/commit/9827c60aa424b61a6fd32e4c55c7651e56e0002c)
+- [[KYUUBI #3742] Add FileSessionConfAdvisor to manage session level configuration](https://github.com/apache/kyuubi/commit/8788c3b2f348d880c35bdc7c36d84f5ad9d05cfe)
+- [[KYUUBI #3766] Support real user for KyuubiSession](https://github.com/apache/kyuubi/commit/20fca4cfa48a8d8b8c84d9181c490dc37de460bf)
+- [[KYUUBI #3835] Allow to use spark-internal as resource for batch job](https://github.com/apache/kyuubi/commit/b225a4293608c128c8d3b3bb0f0961944ade7bd1)
+- [[KYUUBI #3839] Introduce signature mechanism to protect session variable on engine side](https://github.com/apache/kyuubi/commit/4b74129372448925fd5de38cc901edaea164166a)
+- [[KYUUBI #3844] Forward the server ip in openSession](https://github.com/apache/kyuubi/commit/ce11e35822b73c688cec1337161dbf5ebf77d0d3)
+- [[KYUUBI #3847] Add jdbc-shaded profile to support IDE debug](https://github.com/apache/kyuubi/commit/e49f7754316263df6b4927aa3826ba2a781dab87)
+- [[KYUUBI #3863] Arrow-based results serialization](https://github.com/apache/kyuubi/issues/3863)
+- [[KYUUBI #3867] Init SQL scripts should create table iff table does not exist](https://github.com/apache/kyuubi/commit/325668325b30c5e711dc207cc7e4f5aba35a90d7)
+- [[KYUUBI #3887] Provide kyuubiServerPrincipal as alias for principal in JDBC parameter](https://github.com/apache/kyuubi/commit/70c0451f4f670d50a72f093adca0b91fa49f8d1c)
+- [[KYUUBI #3897] Supplying pluggable GroupProvider](https://github.com/apache/kyuubi/commit/4730d11ad7ac210e47e6f5293b28e260279bafa3)
+- [[KYUUBI #3901] Introduce Trino frontend (experimental)](https://github.com/apache/kyuubi/issues/3901)
+- [[KYUUBI #3922] Only the ApplicationInfo with non-empty id is valid for BatchJobSubmission](https://github.com/apache/kyuubi/commit/1288c2d047268a115d6851f570e257b2013e5a93)
+- [[KYUUBI #3923] Add dedicated batch session idle timeout](https://github.com/apache/kyuubi/commit/93db224eb0a90efab47d55ed7c2a56df41b53de1)
+- [[KYUUBI #3926] Introduce antlr4 to parse query statement](https://github.com/apache/kyuubi/commit/7b5af4ae09d265953d0f26561c668e6c7e77090d)
+- [[KYUUBI #3928] Application state mapping considers FinalApplicationStatus](https://github.com/apache/kyuubi/commit/27b525b5d6f69ccc70b72f388315583587ca6697)
+- [[KYUUBI #3950] Fix the batch metadata in-consistent issue on open batch session failure](https://github.com/apache/kyuubi/commit/eb98f1e2339aba6b02af1af89195f89b52034ebc)
+- [[KYUUBI #3975] Support to post batch session/operation event](https://github.com/apache/kyuubi/commit/40009722cbeb54d1cc1c6e2ac1948bfd6667fb98)
+- [[KYUUBI #3983] [KYUUBI #3982] Introduce refreshing user defaults configs](https://github.com/apache/kyuubi/commit/75d0b7f6b7889b48761c499a697814b4b0bf9613)
+- [[KYUUBI #4021] Fix async start engine failure resulting in inaccurate operation metrics](https://github.com/apache/kyuubi/commit/9fd3b80785e949d32bd11e6047cba30d0afd8d5a)
+- [[KYUUBI #4106] Introduce resource file uploading in batch creation via REST API](https://github.com/apache/kyuubi/commit/501c97f3a362679ea964c2ced7b59ca48ee4f855)
+- [[KYUUBI #4119] Return app submission time for batch](https://github.com/apache/kyuubi/commit/35824f5f2c0f617c51cc9ebfa60799fefffee237)
+- [[KYUUBI #4145] Change lock and polling seq_num path on service discovery](https://github.com/apache/kyuubi/commit/547e5ca6176d386f5d8a8b9aadb9c285450f0e37)
+- [[KYUUBI #4151] Support to ignore subdomain when engine pool conditions are met](https://github.com/apache/kyuubi/commit/03fe8a8b96c43a9a9dcb5f0d80cf1b2d97404d8c)
+- [[KYUUBI #4152] Enhance LDAP authentication](https://github.com/apache/kyuubi/commit/eb1b11cd171fd4475cd2168e1d2d573232e16bd9)
+- [[KYUUBI #4241] Only force close engine ref when open session failed](https://github.com/apache/kyuubi/commit/eb1b11cd171fd4475cd2168e1d2d573232e16bd9)
+- [[KYUUBI #4322] MySQL URL configuration joiner should use `&` instead of `;`](https://github.com/apache/kyuubi/commit/fcd3e6f7457fdc5c9ee2f671da4c4940456be79b)
+- [[KYUUBI #4352] Support System.gc() with periodic GC interval](https://github.com/apache/kyuubi/commit/2db326ced9c55bcee41026dc6afd29b40786f0d7)
+- [[KYUUBI #4360] Support to refresh the unlimited users for session limiter](https://github.com/apache/kyuubi/commit/709c66454dfe966a57e39469b4ae862f037c6912)
+- [[KYUUBI #4372] Support to return null value for OperationsResource RowSet](https://github.com/apache/kyuubi/commit/c4955e601a561ce6b483f90d3022fe6d36cb4e03)
+- [[KYUUBI #4390] Allow user to provide batch id on submitting batch job](https://github.com/apache/kyuubi/commit/ac49c77e02c8a3a60df8f5998f4549b6480f91a7)
+- [[KYUUBI #4418] Allow disable async retry and fail fast on unrecoverable DB error](https://github.com/apache/kyuubi/commit/869a008e29d130e22709628243028e3c9d6e3bc3)
+- [[KYUUBI #4419] Implement simple EngineSecuritySecretProvider](https://github.com/apache/kyuubi/commit/4ffe8922d5d95eba6ea6e722876500c8c84b0c94)
 
 ### Client
 
-- [KYUUBI #3973] Fix conf fallback for `kyuubi-ctl list server`
-- [KYUUBI #4006] Fix the incorrect execution of the source command
-- [KYUUBI #4067] Reset the operation log before fetching new one
-- [KYUUBI #4216] Support to transfer client version for JDBC and REST client
-- [KYUUBI #4221] REST client for creating batch with uploading resource file
-- [KYUUBI #4311] Fix the wrong parsing of JVM parameters in JDBC url
-- [KYUUBI #4334] REST client should catch `NoHttpResponse Exception` and retry
+- [[KYUUBI #3973] Fix conf fallback for `kyuubi-ctl list server`](https://github.com/apache/kyuubi/commit/4d6942cb2b5ef68c3026b4e6f875f8ab1b174d0e)
+- [[KYUUBI #4006] Fix the incorrect execution of the source command](https://github.com/apache/kyuubi/commit/a494aa9b8765f3183c960825a5b1a1b47bc2b8a7)
+- [[KYUUBI #4067] Reset the operation log before fetching new one](https://github.com/apache/kyuubi/commit/2c6f17daf13c94d8b0644e59cd48b9c0a93478c7)
+- [[KYUUBI #4216] Support to transfer client version for JDBC and REST client](https://github.com/apache/kyuubi/commit/c14e914f0cb9b72d74842bd7c77a320c83e9b5cb)
+- [[KYUUBI #4221] REST client for creating batch with uploading resource file](https://github.com/apache/kyuubi/commit/37cf4cb29ec61c82ed022b81fc11c6908ea785e5)
+- [[KYUUBI #4311] Fix the wrong parsing of JVM parameters in JDBC url](https://github.com/apache/kyuubi/commit/89d4a4b8446a7054e18efd817cb787aa8aa700ae)
+- [[KYUUBI #4334] REST client should catch `NoHttpResponse Exception` and retry](https://github.com/apache/kyuubi/commit/f03678d0f39927391a24897ac6bd86a3b43f1b44)
 
 ### Spark Engine
 
-- [KYUUBI #3128] Support CostMode for PlanOnlyStatement
-- [KYUUBI #3385] Set executor Pod name prefix if missing in Spark on K8s case
-- [KYUUBI #3441] Change default Spark version to 3.3.1
-- [KYUUBI #3487] Support Kyuubi as Spark dialect
-- [KYUUBI #3776] Revise Kyuubi Spark engine shaded
-- [KYUUBI #3780] Add support for executing Python/PySpark scripts (experimental)
-- [KYUUBI #3792] Engine UI support grace stop
-- [KYUUBI #3801] Correctly calculate active stages in SQLOperationListener
-- [KYUUBI #3851] Support auto set up spark.master when Kyuubi running inside K8s Pod
-- [KYUUBI #3885] Fix memory leak when using incremental collect mode
-- [KYUUBI #3892] Remove sensitive kyuubi.engine.credentials from spark conf
-- [KYUUBI #4035] Post SparkOperationEvent and show sessionId for statements
-- [KYUUBI #4150] Support to execute Scala statement synchronized to prevent conflicts
-- [KYUUBI #4316] Fix returned Timestamp values may lose precision
-- [KYUUBI #4336] Avoid listing all schemas for Spark session catalog on schema pruning
-- [KYUUBI #4407] Adapt SLF4J 2.x
-- [KYUUBI #4412] Align the session handle between server and engine for Spark engine
+- [[KYUUBI #3128] Support CostMode for PlanOnlyStatement](https://github.com/apache/kyuubi/commit/8870183ed70f531f73abfd80f15640486a4fabef)
+- [[KYUUBI #3385] Set executor Pod name prefix if missing in Spark on K8s case](https://github.com/apache/kyuubi/commit/c454bfdcbeb336d47d670ccf5ff84e45bf79a20b)
+- [[KYUUBI #3441] Change default Spark version to 3.3.1](https://github.com/apache/kyuubi/commit/f7c08dcafac40e5b4f377602abbb676744e671e0)
+- [[KYUUBI #3487] Support Kyuubi as Spark dialect](https://github.com/apache/kyuubi/commit/1a9bf9305119ca43d3aa0dfb7fe55661679463e0)
+- [[KYUUBI #3776] Revise Kyuubi Spark engine shaded](https://github.com/apache/kyuubi/commit/72c1f53dd0c4a8eafb9ee2b13c77240b711cb58d)
+- [[KYUUBI #3780] Add support for executing Python/PySpark scripts (experimental)](https://github.com/apache/kyuubi/issues/3780)
+- [[KYUUBI #3792] Engine UI support grace stop](https://github.com/apache/kyuubi/commit/7ee25b2220d683fc1361511412c06f2d3b49cc31)
+- [[KYUUBI #3801] Correctly calculate active stages in SQLOperationListener](https://github.com/apache/kyuubi/commit/979881d6877bef42faee3410f5796966258e235e)
+- [[KYUUBI #3851] Support auto set up spark.master when Kyuubi running inside K8s Pod](https://github.com/apache/kyuubi/commit/5fdd44fe6b20ab1a4a85b80156bbb8d0bb14d214)
+- [[KYUUBI #3885] Fix memory leak when using incremental collect mode](https://github.com/apache/kyuubi/commit/172f42735509222373c8012bb9f821600f6d722d)
+- [[KYUUBI #3892] Remove sensitive kyuubi.engine.credentials from spark conf](https://github.com/apache/kyuubi/commit/87d01b577cfd006f3f66b689f05da32ce3d1b947)
+- [[KYUUBI #4035] Post SparkOperationEvent and show sessionId for statements](https://github.com/apache/kyuubi/commit/a96df17bcdba2b9de3d4c6e520f8baf1f03c45ce)
+- [[KYUUBI #4150] Support to execute Scala statement synchronized to prevent conflicts](https://github.com/apache/kyuubi/commit/4669163176c71f9ecce5b8bd238ff61d73e59e23)
+- [[KYUUBI #4316] Fix returned Timestamp values may lose precision](https://github.com/apache/kyuubi/commit/8fe794709bb2a3e28baa6dccf89f62b1dac5c285)
+- [[KYUUBI #4336] Avoid listing all schemas for Spark session catalog on schema pruning](https://github.com/apache/kyuubi/commit/89fe835b93ea26d1c2ce5d9991a284449d16caa2)
+- [[KYUUBI #4407] Adapt SLF4J 2.x](https://github.com/apache/kyuubi/commit/0175e4649a66c7e0e7cda5914e730382c5c763b0)
+- [[KYUUBI #4412] Align the session handle between server and engine for Spark engine](https://github.com/apache/kyuubi/commit/c0241052ae156971a07ee30d89bc4a02d6115d3e)
 
-### Spark Authz Plugin 
+### Spark Authz Plugin
 
-- [KYUUBI #3424] Access privilege checks for namespaces and tables of DatasourceV2
-- [KYUUBI #3515] Support Iceberg commands and skip apply row-filter to output tables
-- [KYUUBI #3325] Privilege checks for permanent views and skipping shadowed tables
-- [KYUUBI #3300] Support user group based policies from Ranger
-- [KYUUBI #3371] Ranger client support sending requests in batch
-- [KYUUBI #3581] Support row filter and data masking on permanent views
-- [KYUUBI #3607] Support {OWNER} variable defined in Ranger policy
-- [KYUUBI #3904] New Authz Plan Serde Layer
-- [KYUUBI #4076] Modified query plan should correctly report stats
-- [KYUUBI #4270] Register shutdown hook for plugin cleanup
-- [KYUUBI #4255] Handle describe relation for V2 relations
-- [KYUUBI #4262] Rename table requires ALTER privilege of the source table 
-- [KYUUBI #4202] Fix reference resolution when data masking enabled for V2 relations
-- [KYUUBI #4437] Fix dependencies conflict by replacing `jersey-bundle` with `jersey-client`
+- [[KYUUBI #3424] Access privilege checks for namespaces and tables of DatasourceV2](https://github.com/apache/kyuubi/commit/6aacbb754448ac32d05288ab1d1bb1e6b78bd438)
+- [[KYUUBI #3515] Support Iceberg commands and skip apply row-filter to output tables](https://github.com/apache/kyuubi/commit/0c2091cd03c92f4b3e402a2dc84ef35cdc5d5bea)
+- [[KYUUBI #3325] Privilege checks for permanent views and skipping shadowed tables](https://github.com/apache/kyuubi/commit/1989e4c7934d7f4d80f488fd0bf9e5adbda5ed9c)
+- [[KYUUBI #3300] Support user group based policies from Ranger](https://github.com/apache/kyuubi/commit/c5e57e946b3d271b4bc0b760d143533c03f1a333)
+- [[KYUUBI #3371] Ranger client support sending requests in batch](https://github.com/apache/kyuubi/commit/23a8ccd538c72ba38770941928f5a7e161dd2af7)
+- [[KYUUBI #3581] Support row filter and data masking on permanent views](https://github.com/apache/kyuubi/commit/8207b106207cb119c859cc81c59decac9b09b799)
+- [[KYUUBI #3607] Support {OWNER} variable defined in Ranger policy](https://github.com/apache/kyuubi/issues/3607)
+- [[KYUUBI #3904] New Authz Plan Serde Layer](https://github.com/apache/kyuubi/commit/2540f44a8769a538a34a3256fb66f4346d6de79e)
+- [[KYUUBI #4076] Modified query plan should correctly report stats](https://github.com/apache/kyuubi/commit/71e46bd3168c4ce530d96d38ebc7e9209f03c498)
+- [[KYUUBI #4270] Register shutdown hook for plugin cleanup](https://github.com/apache/kyuubi/commit/0eff3cec535464f08cf6162971b4a80a48536132)
+- [[KYUUBI #4255] Handle describe relation for V2 relations](https://github.com/apache/kyuubi/commit/e5743c8309978cfc2bf430721d0c9d2d46909883)
+- [[KYUUBI #4262] Rename table requires ALTER privilege of the source table](https://github.com/apache/kyuubi/commit/68cc0e40970453e59351d199396a2c546afb8c08)
+- [[KYUUBI #4202] Fix reference resolution when data masking enabled for V2 relations](https://github.com/apache/kyuubi/commit/5aed270c453516fd3559aa668e56b2e1badf1c93)
+- [[KYUUBI #4437] Fix dependencies conflict by replacing `jersey-bundle` with `jersey-client`](https://github.com/apache/kyuubi/commit/355ed803b6d8b55c7b076640d48fcf01b951782f)
 
 ### Other Spark Extensions
 
-- [KYUUBI #2282] Introduce Spark Lineage plugin (experimental)
-- [KYUUBI #3365] Introduce Spark Hive connector (experimental)
-- [KYUUBI #3601] Support infer columns for rebalance and sort
-- [KYUUBI #3962] Add two conditions to decide if add shuffle before writing
-- [KYUUBI #3988] Final stage config isolation support write only
-- [KYUUBI #3893] UnspecifiedDistribution does not have default partitioning
+- [[KYUUBI #2282] Introduce Spark Lineage plugin (experimental)](https://github.com/apache/kyuubi/commit/9716548380a21f2608ec1f413f1f6986366b4f18)
+- [[KYUUBI #3365] Introduce Spark Hive connector (experimental)](https://github.com/apache/kyuubi/issues/3365)
+- [[KYUUBI #3601] Support infer columns for rebalance and sort](https://github.com/apache/kyuubi/commit/2acee9ea977f7b5ae3d270be93ec0b2537eac4dd)
+- [[KYUUBI #3962] Add two conditions to decide if add shuffle before writing](https://github.com/apache/kyuubi/commit/fa9e6be663f4eb4f611963583a4fa6a7340a8cef)
+- [[KYUUBI #3988] Final stage config isolation support write only](https://github.com/apache/kyuubi/commit/04953500821840e5e99fda0245400d5fea1e6182)
+- [[KYUUBI #3893] UnspecifiedDistribution does not have default partitioning](https://github.com/apache/kyuubi/commit/8ef6494e4a887145b9cbb451ce7b63b435557fc1)
 
 ### Flink Engine
 
-- [KYUUBI #3514] Support Flink 1.16
-- [KYUUBI #3604] Propagate HADOOP_PROXY_USER on launching Flink engine
-- [KYUUBI #3717] Support Flink engine see primary keys
+- [[KYUUBI #3514] Support Flink 1.16](https://github.com/apache/kyuubi/commit/214d238902712e3f2b6e49507c2fcf762f80ef9b)
+- [[KYUUBI #3604] Propagate HADOOP_PROXY_USER on launching Flink engine](https://github.com/apache/kyuubi/commit/26b78f5c1fb02b9e6bdce96b633bacddb43c229f)
+- [[KYUUBI #3717] Support Flink engine see primary keys](https://github.com/apache/kyuubi/commit/a2604b1a89a115c339e87f7679188e205abb9707)
 
 ### Other Notable Changes
 
-- [KYUUBI #3473] Add Docker Compose based Kyuubi playground
-- [KYUUBI #3903] Support generate `kyuubi-version-info.properties` on Windows
-- [KYUUBI #4000] JDBC engine supports Apache Phoenix
-- [KYUUBI #4288] Use eclipse-temurin:8-jdk-focal as default base image
-- [KYUUBI #4320] Trino engine supports GetPrimaryKeys
-- [KYUUBI #4473] Helm Chart improvements
+- [[KYUUBI #3473] Add Docker Compose based Kyuubi playground](https://github.com/apache/kyuubi/commit/5dd245dfa1e7302fbdcc743eba0d4fd5f2ab1655)
+- [[KYUUBI #3903] Support generate `kyuubi-version-info.properties` on Windows](https://github.com/apache/kyuubi/commit/730fd57ccf6accf5636ad7bef13b16e8727de8ee)
+- [[KYUUBI #4000] JDBC engine supports Apache Phoenix](https://github.com/apache/kyuubi/commit/32b06c648ac34be7a3478026a40cff353f5d7b8f)
+- [[KYUUBI #4288] Use eclipse-temurin:8-jdk-focal as default base image](https://github.com/apache/kyuubi/commit/5318585550bd1e0921e95fea10637d3fe4b04ea3)
+- [[KYUUBI #4320] Trino engine supports GetPrimaryKeys](https://github.com/apache/kyuubi/commit/02deaf4756fef953d706f171d87c5d0dd760f264)
+- [[KYUUBI #4473] Helm Chart improvements](https://github.com/apache/kyuubi/issues/4473)
 
 ### Credits
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add links for commits in 1.7.0 release note.

- Most commits can find the corresponding link after the code review.
- A few commits use a issue link because they are large features or contain many subtasks, e.g:
  
  Please check if it's okay.

  - [[KYUUBI #3554] REST API functions/command-line tool enhancements](https://github.com/apache/kyuubi/issues/3554)
  - [[KYUUBI #3863] Arrow-based results serialization](https://github.com/apache/kyuubi/issues/3863)
  - [[KYUUBI #3901] Introduce Trino frontend (experimental)](https://github.com/apache/kyuubi/issues/3901)
  - [[KYUUBI #3780] Add support for executing Python/PySpark scripts (experimental)](https://github.com/apache/kyuubi/issues/3780)
  - [[KYUUBI #3607] Support {OWNER} variable defined in Ranger policy](https://github.com/apache/kyuubi/issues/3607)
  - [[KYUUBI #3365] Introduce Spark Hive connector (experimental)](https://github.com/apache/kyuubi/issues/3365)
  - [[KYUUBI #4473] Helm Chart improvements](https://github.com/apache/kyuubi/issues/4473)

2. Fix a typo in 1.7.0.md
```
Init SQL scripts should create table iff table does not exist

 should be 

Init SQL scripts should create table if table does not exist
```

### Why are the changes needed?

It is convenient for users to view release notes and associate them with specific commits or issues

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

No need.

