### PR TITLE
Workaround for 1.7.1 build failure by urllib3 removing support openssl@1.0.x

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,7 +27,17 @@
         </p>
         <div class="bannerBtnContainer">
           {{ range $release := first 1 .Site.Params.releases }}
-            <a class="bannerBtn" href="https://kyuubi.readthedocs.io/en/{{ $release }}/quick_start">{{ i18n "getting-started" }} »</a>
+          <!--
+            TODO: Remove this workaround when
+              - the build of readthedocs supports OpenSSL 1.1.1+
+              - 1.7.2 comes out
+            More info: https://github.com/urllib3/urllib3/issues/2168
+           -->
+          {{ $fixed_release := $release }}
+          {{ if eq $release "v1.7.1" }}
+          {{ $fixed_release = "v1.7.1-rc0" }}
+          {{ end }}
+            <a class="bannerBtn" href="https://kyuubi.readthedocs.io/en/{{ $fixed_release }}/quick_start">{{ i18n "getting-started" }} »</a>
           {{ end }}
           <a class="bannerBtn" href="https://github.com/apache/kyuubi">GitHub »</a>
         </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -35,7 +35,17 @@
         {{if or (eq .Identifier "docs") }}
         {{range $idx, $release := $currentPage.Site.Params.releases }}
         <li>
-          <a class="childNavLink" href="https://kyuubi.readthedocs.io/en/{{ $release }}/">
+          <!--
+            TODO: Remove this workaround when
+              - the build of readthedocs supports OpenSSL 1.1.1+
+              - 1.7.2 comes out
+            More info: https://github.com/urllib3/urllib3/issues/2168
+           -->
+          {{ $fixed_release := $release }}
+          {{ if eq $release "v1.7.1" }}
+          {{ $fixed_release = "v1.7.1-rc0" }}
+          {{ end }}
+          <a class="childNavLink" href="https://kyuubi.readthedocs.io/en/{{ $fixed_release }}/">
             {{ trim $release "v"}}
             {{ if (eq $idx 0) }}
               (latest)


### PR DESCRIPTION
1.7.1 and master doc building failed because https://github.com/urllib3/urllib3/issues/2168. We have fixed the master and branch-1.7 via https://github.com/apache/kyuubi/pull/4800. Unfortunately, 1.7.1 has been finalized and can not be patched.

In this PR, we redirect 1.7.1 to 1.7.1-rc0, which has the same revision as 1.7.1.
