### PR TITLE
fix the order of released versions in docs links

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -337,6 +337,6 @@ defaultContentLanguage = 'en'
     keepQuotes = true
 
 [params]
-  releases = [ 'v1.10.0','v1.9.3', 'v1.8.3', 'v1.7.4', 'v1.6.1-incubating', 'v1.5.2-incubating', 'v1.4.1-incubating', 'v1.3.1-incubating' ]
+  releases = [ 'v1.9.3', 'v1.8.3', 'v1.10.0', 'v1.7.4', 'v1.6.1-incubating', 'v1.5.2-incubating', 'v1.4.1-incubating', 'v1.3.1-incubating' ]
   downloadLink = 'https://www.apache.org/dyn/closer.lua/kyuubi/'
   downloadLinkIncubator = 'https://www.apache.org/dyn/closer.lua/incubator/kyuubi/'


### PR DESCRIPTION
# Description
Adjusted the order of release numbers
- The docs menu on the website
- Get started entrance on the website

# Before
As shown on the document menu, 1.10 is the latest version
![image](https://github.com/user-attachments/assets/4c9f5396-8308-45af-94e9-dff5c6a75f3e)


# After
Now according to the release order, it is adjusted to 1.9.3 as the latest version
![image](https://github.com/user-attachments/assets/189cfc0f-8af4-49f9-af22-a64aba035499)

