### PR TITLE
fix the latest release in the site

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -337,6 +337,7 @@ defaultContentLanguage = 'en'
     keepQuotes = true
 
 [params]
+  releaseVersion = '1.10.0'
   releases = [ 'v1.10.0','v1.9.3', 'v1.8.3', 'v1.7.4', 'v1.6.1-incubating', 'v1.5.2-incubating', 'v1.4.1-incubating', 'v1.3.1-incubating' ]
   downloadLink = 'https://www.apache.org/dyn/closer.lua/kyuubi/'
   downloadLinkIncubator = 'https://www.apache.org/dyn/closer.lua/incubator/kyuubi/'

--- a/hugo.toml
+++ b/hugo.toml
@@ -337,7 +337,7 @@ defaultContentLanguage = 'en'
     keepQuotes = true
 
 [params]
-  releaseVersion = '1.10.0'
+  latestRelease = '1.10.0'
   releases = [ 'v1.10.0','v1.9.3', 'v1.8.3', 'v1.7.4', 'v1.6.1-incubating', 'v1.5.2-incubating', 'v1.4.1-incubating', 'v1.3.1-incubating' ]
   downloadLink = 'https://www.apache.org/dyn/closer.lua/kyuubi/'
   downloadLinkIncubator = 'https://www.apache.org/dyn/closer.lua/incubator/kyuubi/'

--- a/layouts/custompage/release.html
+++ b/layouts/custompage/release.html
@@ -31,7 +31,7 @@
     {{ if ne .Site.Language.Lang "en" }}
     {{ $langVar = .Site.Language.Lang }}
     {{ end }}
-    {{ range first 1 (sort (where (where .Site.Pages "Section" "release") ".Params.linked" true) ".Date" "desc") }}
+    {{ range first 1 (sort (where (where (where .Site.Pages "Section" "release") ".Params.linked" true) ".File.BaseFileName" .Site.Params.releaseVersion  ) ".Date" "desc") }}
     <tr>
       {{ $dir := print "kyuubi-" .File.BaseFileName "/" }}
       {{ $source := print "apache-kyuubi-" .File.BaseFileName "-source.tgz" }}

--- a/layouts/custompage/release.html
+++ b/layouts/custompage/release.html
@@ -31,7 +31,7 @@
     {{ if ne .Site.Language.Lang "en" }}
     {{ $langVar = .Site.Language.Lang }}
     {{ end }}
-    {{ range first 1 (sort (where (where (where .Site.Pages "Section" "release") ".Params.linked" true) ".File.BaseFileName" .Site.Params.latestRelease  ) ".Date" "desc") }}
+    {{ range  where (where (where .Site.Pages "Section" "release") ".Params.linked" true) ".File.BaseFileName" .Site.Params.latestRelease  }}
     <tr>
       {{ $dir := print "kyuubi-" .File.BaseFileName "/" }}
       {{ $source := print "apache-kyuubi-" .File.BaseFileName "-source.tgz" }}

--- a/layouts/custompage/release.html
+++ b/layouts/custompage/release.html
@@ -31,7 +31,7 @@
     {{ if ne .Site.Language.Lang "en" }}
     {{ $langVar = .Site.Language.Lang }}
     {{ end }}
-    {{ range first 1 (sort (where (where (where .Site.Pages "Section" "release") ".Params.linked" true) ".File.BaseFileName" .Site.Params.releaseVersion  ) ".Date" "desc") }}
+    {{ range first 1 (sort (where (where (where .Site.Pages "Section" "release") ".Params.linked" true) ".File.BaseFileName" .Site.Params.latestRelease  ) ".Date" "desc") }}
     <tr>
       {{ $dir := print "kyuubi-" .File.BaseFileName "/" }}
       {{ $source := print "apache-kyuubi-" .File.BaseFileName "-source.tgz" }}


### PR DESCRIPTION
# Description
Fixed the display of the latest stable version on this page https://kyuubi.apache.org/releases.html
- change：add a variable to define the latest version number

# Before 
![image](https://github.com/user-attachments/assets/2872f913-d270-4d21-a710-cf02f711f41b)

# After 
![image](https://github.com/user-attachments/assets/ad3c265e-f98a-4823-8e8c-0f0600864dee)
